### PR TITLE
Updated method for mining with biased data

### DIFF
--- a/code/psiMiner.c
+++ b/code/psiMiner.c
@@ -215,6 +215,7 @@ int main(int argc, char *argv[]) {
 		
 		N = inputConfig->N+1;
 		K = inputConfig->K;
+		strict = inputConfig->strict;
 		
 		listOfIntervalSets = (struct listOfIntervalListsStruct**)malloc(sizeof(struct listOfIntervalListsStruct*)*(inputConfig->traceCount));
 		bzero(listOfIntervalSets,sizeof(struct listOfIntervalListsStruct*)*(inputConfig->traceCount));
@@ -238,7 +239,7 @@ int main(int argc, char *argv[]) {
 		
 		//---------------------------------Parsing Interval Sets--------------------------------------
 		#ifdef MAIN_DEBUG
-			fprintf(logFile,"[AMSMiner] Parsing Intervals.\n");fflush(logFile);
+			fprintf(logFile,"[PSIMiner] Parsing Intervals.\n");fflush(logFile);
 		#endif
 		
 		setbuf(stdout, NULL);
@@ -286,8 +287,8 @@ int main(int argc, char *argv[]) {
 		
                 
 //		#ifdef MAIN_DEBUG
-//		fprintf(logFile,"[AMSMiner] intervalSet = %p\n",intervalSet);
-//		fprintf(logFile,"[AMSMiner] From the Main Codebase:\n");fflush(logFile);
+//		fprintf(logFile,"[PSIMiner] intervalSet = %p\n",intervalSet);
+//		fprintf(logFile,"[PSIMiner] From the Main Codebase:\n");fflush(logFile);
 //		printListOfIntervalListsToFilePtr(intervalSet,logFile);
 //		fflush(logFile);
 //		#endif
@@ -296,7 +297,7 @@ int main(int argc, char *argv[]) {
 		numberOfPORVs = countLists(listOfIntervalSets[0]);
                 
                 #ifdef MAIN_DEBUG
-		fprintf(logFile,"[AMSMiner] Number of PORVs = %d\n",numberOfPORVs);
+		fprintf(logFile,"[PSIMiner] Number of PORVs = %d\n",numberOfPORVs);
                 #endif
 		
 		printPredicateList(predicateMap);
@@ -311,7 +312,7 @@ int main(int argc, char *argv[]) {
         //targetPORV_id = target;			//TODO: Merge this and the previous lines
 
 		//#ifdef MAIN_DEBUG
-		//fprintf(logFile,"[AMSMiner] Target PORV ID: P-%d\n",targetPORV_id);
+		//fprintf(logFile,"[PSIMiner] Target PORV ID: P-%d\n",targetPORV_id);
 		//#endif
                 //--------------------------------------------------------------------------------------------
 			

--- a/examples/grid-world/risky_all.conf
+++ b/examples/grid-world/risky_all.conf
@@ -1,4 +1,4 @@
-seqLength=4
+seqLength=3
 delayRes=1
 traceCount=4
 traceFile=t1.csv, t2.csv, t3.csv, t4.csv
@@ -7,6 +7,7 @@ tmin=1
 tmax=5
 learnMode=0
 depth=4
+strict=1
 
 start 1
 
@@ -16,15 +17,13 @@ safety 3 1
 begin
 
 type==1
-type==2
 safety==0
 
 end
 
 LAND = (1)
-WATER = (2)
-UNSAFE = (3)
+UNSAFE = (2)
 
 targets begin
-(3)
+(2)
 end

--- a/examples/grid-world/t2.csv
+++ b/examples/grid-world/t2.csv
@@ -9,3 +9,4 @@ timestamp,type,safe
 7,2,1
 8,2,1
 9,1,1
+10,1,1


### PR DESCRIPTION
Added strictness constraints to allow strict temporal semantics, allowing delays of the type ##[k:k] in place of #[0:k]. This is enabled by setting strict=1 in the configuration file used with the example. Also enabled biased learning.